### PR TITLE
SAKAI-3250 Canceling and deleting redirect fix

### DIFF
--- a/tool/src/webapp/WEB-INF/templates/create_comment.hbs
+++ b/tool/src/webapp/WEB-INF/templates/create_comment.hbs
@@ -9,4 +9,4 @@
 	<br />
     <input id="clog_comment_id_field" type="hidden" value="{{id}}"/>
     <input id="clog_save_comment_button" type="button" value="{{translate 'save'}}"/>
-    <input type="button" value="{{translate 'cancel'}}" onclick="clog.switchState('viewAllPosts');"/>
+    <input type="button" value="{{translate 'cancel'}}" onclick="clog.switchState('post',{postId: '{{postId}}',fromSamepage: true});"/>

--- a/tool/src/webapp/js/clog_utils.js
+++ b/tool/src/webapp/js/clog_utils.js
@@ -412,7 +412,22 @@ clog.utils = {
             type:'DELETE',
             timeout: clog.AJAX_TIMEOUT,
             success: function (text, status) {
-                clog.switchState('viewAllPosts');
+                if ('post' === clog.currentState)
+                {
+                    clog.switchState('post',{postId: (clog.currentPost.id),fromSamepage: true});
+                }
+                else if ('userPosts' === clog.currentState)
+                {
+                    clog.switchState('userPosts');
+                }
+                else if ('viewRecycled' === clog.currentState)
+                {
+                    clog.switchState('viewRecycled');
+                }
+                else
+                {
+                    clog.switchState('viewAllPosts');
+                }
             },
             error: function (xmlHttpRequest, textStatus, error) {
                 alert("Failed to delete comment. Status: " + textStatus + ". Error: " + error);


### PR DESCRIPTION
Canceling editing a comment now redirects you back to the post
where the comment was to be added
Deleting a comment now returns you to the page where you deleted
the comment instead of defaulting to view all posts